### PR TITLE
Temporarily disable zh.md check for docs-cn

### DIFF
--- a/docs-cn/verify.yaml
+++ b/docs-cn/verify.yaml
@@ -75,11 +75,11 @@ tasks:
     buildEnv:
       image: node:lts
 
-  - name: zhmd lint
-    taskType: common
-    shellScript: |
-      npm install -g preset-lint-zh
-      zhmd -c .zhlint.yaml
-    buildEnv:
-      image: node:lts
+#  - name: zhmd lint
+#    taskType: common
+#    shellScript: |
+#      npm install -g preset-lint-zh
+#      zhmd -c .zhlint.yaml
+#    buildEnv:
+#      image: node:lts
 


### PR DESCRIPTION
Temporarily disable zh.md check for docs-cn, because this check is not 100% accurate and might misreport errors.