### PR TITLE
tiem/golangci-lint.yaml: filter out errcheck rule

### DIFF
--- a/tiem/golangci-lint.yaml
+++ b/tiem/golangci-lint.yaml
@@ -13,7 +13,6 @@ linters:
       - deadcode
       - gosimple
       - goimports
-      - errcheck
       - staticcheck
       - stylecheck
       - gosec


### PR DESCRIPTION
TiEM这边我们还没想好如何改进错误检查，申请临时关闭这条规则，待确定后再开启