### PR TITLE
docs/docs-cn: comment out buggy internal link checks

### DIFF
--- a/docs-cn/verify.yaml
+++ b/docs-cn/verify.yaml
@@ -31,19 +31,19 @@ tasks:
     buildEnv:
       image: node:lts
 
-  - name: Check internal links
-    taskType: common
-    shellScript: |
-      ./scripts/verify-links.sh
-    buildEnv:
-      image: node:lts
+  # - name: Check internal links
+  #   taskType: common
+  #   shellScript: |
+  #     ./scripts/verify-links.sh
+  #   buildEnv:
+  #     image: node:lts
 
-  - name: Check internal link anchorss
-    taskType: common
-    shellScript: |
-      ./scripts/verify-link-anchors.sh
-    buildEnv:
-      image: node:lts
+  # - name: Check internal link anchorss
+  #   taskType: common
+  #   shellScript: |
+  #     ./scripts/verify-link-anchors.sh
+  #   buildEnv:
+  #     image: node:lts
 
   - name: "Check control characters"
     taskType: common

--- a/docs/verify.yaml
+++ b/docs/verify.yaml
@@ -31,19 +31,19 @@ tasks:
     buildEnv:
       image: node:lts
 
-  - name: Check internal links
-    taskType: common
-    shellScript: |
-      ./scripts/verify-links.sh
-    buildEnv:
-      image: node:lts
+  # - name: Check internal links
+  #   taskType: common
+  #   shellScript: |
+  #     ./scripts/verify-links.sh
+  #   buildEnv:
+  #     image: node:lts
 
-  - name: Check internal link anchorss
-    taskType: common
-    shellScript: |
-      ./scripts/verify-link-anchors.sh
-    buildEnv:
-      image: node:lts
+  # - name: Check internal link anchorss
+  #   taskType: common
+  #   shellScript: |
+  #     ./scripts/verify-link-anchors.sh
+  #   buildEnv:
+  #     image: node:lts
 
   - name: "Check control characters"
     taskType: common


### PR DESCRIPTION
This PR comments out the buggy internal link checks from Jenkins configuration for pingcap/docs and pingcap/docs-cn. The commented-out link checks are added in GitHub Actions in https://github.com/pingcap/docs-cn/pull/7467 and https://github.com/pingcap/docs/pull/6782.