### PR TITLE
verify-ci: add dataflow engine in verify ci

### DIFF
--- a/tiflow/tiflow-verify-go1.18-pipeline.yaml
+++ b/tiflow/tiflow-verify-go1.18-pipeline.yaml
@@ -81,6 +81,27 @@ tasks:
         - jenkinsID: coveralls-token-ticdc
           key: TICDC_COVERALLS_TOKEN
 
+    - taskName: "engine-ut" 
+      checkerName: "ut-check" 
+      params:  
+        shellScript: |
+            make engine_unit_test_in_verify_ci
+        utReport: engine-junit-report.xml
+        covReport: engine-coverage.xml
+      image: "hub.pingcap.net/jenkins/centos7_golang-1.18:latest"  
+      resources:  
+          requests:
+              memory: "8000Mi"
+              cpu: "4000m"
+          limits:
+              memory: "30000Mi"
+              cpu: "16000m"
+      credentials:
+        - jenkinsID: codecov-token-ticdc
+          key: TICDC_CODECOV_TOKEN
+        - jenkinsID: coveralls-token-ticdc
+          key: TICDC_COVERALLS_TOKEN
+
     # - taskName: "dm-gosec" 
     #   checkerName: "gosec-check" 
     #   params:  


### PR DESCRIPTION
ref: https://github.com/pingcap/tiflow/pull/5501

- Run `make engine_unit_test_in_verify_ci` in tiflow-verify-go1.18-pipeline

**Don't merge this PR until https://github.com/pingcap/tiflow/pull/5501 is merged.**