### PR TITLE
tiflow-verify-go1.19-pipeline-master: Switch to Go 1.19 image for tiflow-lint

### DIFF
--- a/tiflow/tiflow-verify-go1.19-pipeline-master.yaml
+++ b/tiflow/tiflow-verify-go1.19-pipeline-master.yaml
@@ -14,7 +14,7 @@ tasks:
       params:  
         shellScript: |
             make check
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.18.5:latest"  
+      image: "hub.pingcap.net/jenkins/centos7_golang-1.19:latest"
       resources:  
           requests:
               memory: "1000Mi"


### PR DESCRIPTION
Related to https://github.com/pingcap/tiflow/pull/7240
