### PR TITLE
Fix invalid shell syntax in docs-merge-pipeline

### DIFF
--- a/docs-cn/docs-cn-merge-pipeline.yaml
+++ b/docs-cn/docs-cn-merge-pipeline.yaml
@@ -22,7 +22,7 @@ tasks:
             python3 scripts/upload.py output.pdf tidb-dev-zh-manual.pdf;
           elif [ "${TARGET_BRANCH}" = "release-6.1" ]; then
             python3 scripts/upload.py output.pdf tidb-stable-zh-manual.pdf;
-          elif [[ $TARGET_BRANCH == release-* ]]; then
+          elif case "${TARGET_BRANCH}" in release-*) ;; *) false;; esac; then
             python3 scripts/upload.py output.pdf tidb-v${TARGET_BRANCH##*-}-zh-manual.pdf;
           fi
       credentials:

--- a/docs/docs-merge-pipeline.yaml
+++ b/docs/docs-merge-pipeline.yaml
@@ -25,7 +25,7 @@ tasks:
             python3 scripts/merge_by_toc.py TOC-tidb-cloud.md doc_cloud.md tidb-cloud;
             scripts/generate_cloud_pdf.sh;
             python3 scripts/upload.py output_cloud.pdf tidbcloud-en-manual.pdf;
-          elif [[ $TARGET_BRANCH == release-* ]]; then
+          elif case "${TARGET_BRANCH}" in release-*) ;; *) false;; esac; then
             python3 scripts/upload.py output.pdf tidb-v${TARGET_BRANCH##*-}-en-manual.pdf;
           fi
       credentials:


### PR DESCRIPTION
Ref: https://stackoverflow.com/a/18558871

Jenkins uses POSIX shell instead of bash when running scripts. `[[ $TARGET_BRANCH == release-* ]]` is invalid.