### PR TITLE
fix(pingcap/docs): fix git ownership error

### DIFF
--- a/docs/docs-verify-pipeline.yaml
+++ b/docs/docs-verify-pipeline.yaml
@@ -13,6 +13,7 @@ tasks:
       checkerName: "common-check" 
       params:  
         shellScript: |
+            git config --global --add safe.directory '*'
             git remote add upstream https://github.com/pingcap/docs.git
             git fetch upstream
             wget https://raw.githubusercontent.com/pingcap/docs/master/scripts/check-file-encoding.py
@@ -30,6 +31,7 @@ tasks:
       checkerName: "common-check" 
       params:  
         shellScript: |
+            git config --global --add safe.directory '*'
             git remote add upstream https://github.com/pingcap/docs.git
             git fetch upstream
             wget https://raw.githubusercontent.com/pingcap/docs/master/scripts/check-conflicts.py
@@ -48,6 +50,7 @@ tasks:
       params:  
         shellScript: |
             npm install -g markdownlint-cli@0.17.0
+            git config --global --add safe.directory '*'
             git remote add upstream https://github.com/pingcap/docs.git
             git fetch upstream
             markdownlint $(git diff-tree --name-only --no-commit-id -r upstream/${TARGET_BRANCH}..HEAD -- '*.md' ':(exclude).github/*')
@@ -92,6 +95,7 @@ tasks:
       checkerName: "common-check" 
       params:  
         shellScript: |
+            git config --global --add safe.directory '*'
             git remote add upstream https://github.com/pingcap/docs.git
             git fetch upstream
             wget https://raw.githubusercontent.com/pingcap/docs/master/scripts/check-control-char.py
@@ -109,6 +113,7 @@ tasks:
       checkerName: "common-check" 
       params:  
         shellScript: |
+            git config --global --add safe.directory '*'
             git remote add upstream https://github.com/pingcap/docs.git
             git fetch upstream
             wget https://raw.githubusercontent.com/pingcap/docs/master/scripts/check-tags.py
@@ -126,6 +131,7 @@ tasks:
       checkerName: "common-check" 
       params:  
         shellScript: |
+            git config --global --add safe.directory '*'
             git remote add upstream https://github.com/pingcap/docs.git
             git fetch upstream
             wget https://raw.githubusercontent.com/pingcap/docs/master/scripts/check-manual-line-breaks.py


### PR DESCRIPTION
image node:lts has been updated 6 days ago, git version has been upgrade to 2.30.2.

The following error is currently encountered when running git in ci
```
18:04:29  + git remote add upstream https://github.com/pingcap/docs.git
18:04:29  fatal: detected dubious ownership in repository at '/home/jenkins/agent/workspace/common-check/docs'
18:04:29  To add an exception for this directory, call:
18:04:29  
18:04:29  	git config --global --add safe.directory /home/jenkins/agent/workspace/common-check/docs
```