### PR TITLE
limit the pdf trigger branch to release branch

### DIFF
--- a/docs-cn/docs-cn-merge-pipeline.yaml
+++ b/docs-cn/docs-cn-merge-pipeline.yaml
@@ -5,7 +5,17 @@ triggers:
   push:
       onBranch:
       - "master"
-      - "release-*"
+      - "release-7.0"
+      - "release-6.6"
+      - "release-6.5"
+      - "release-6.1"
+      - "release-5.4"
+      - "release-5.3"
+      - "release-5.2"
+      - "release-5.1"
+      - "release-5.0"
+      - "release-4.0"
+      - "release-3.0"
 tasks:
     - taskName: "docs-cn-build-pdf"
       checkerName: "common-check"

--- a/docs-tidb-operator/docs-tidb-operator-merge-pipeline.yaml
+++ b/docs-tidb-operator/docs-tidb-operator-merge-pipeline.yaml
@@ -5,7 +5,10 @@ triggers:
   push:
       onBranch:
       - "master"
-      - "release-*"
+      - "release-1.5"
+      - "release-1.4"
+      - "release-1.3"
+      - "release-1.2"
 tasks:
     - taskName: "docs-tidb-operator-build-pdf"
       checkerName: "common-check"

--- a/docs/docs-merge-pipeline.yaml
+++ b/docs/docs-merge-pipeline.yaml
@@ -5,7 +5,17 @@ triggers:
   push:
       onBranch:
       - "master"
-      - "release-*"
+      - "release-7.0"
+      - "release-6.6"
+      - "release-6.5"
+      - "release-6.1"
+      - "release-5.4"
+      - "release-5.3"
+      - "release-5.2"
+      - "release-5.1"
+      - "release-5.0"
+      - "release-4.0"
+      - "release-3.0"
 tasks:
     - taskName: "docs-build-pdf"
       checkerName: "common-check"
@@ -22,8 +32,8 @@ tasks:
             python3 scripts/upload.py output.pdf tidb-dev-en-manual.pdf;
           elif [ "${TARGET_BRANCH}" = "release-6.5" ]; then
             python3 scripts/upload.py output.pdf tidb-stable-en-manual.pdf;
-            python3 scripts/merge_by_toc.py TOC-tidb-cloud.md doc_cloud.md tidb-cloud; scripts/generate_cloud_pdf.sh; 
-            python3 scripts/upload.py output_cloud.pdf tidbcloud-en-manual.pdf; 
+            python3 scripts/merge_by_toc.py TOC-tidb-cloud.md doc_cloud.md tidb-cloud; scripts/generate_cloud_pdf.sh;
+            python3 scripts/upload.py output_cloud.pdf tidbcloud-en-manual.pdf;
           elif case "${TARGET_BRANCH}" in release-*) ;; *) false;; esac; then
             python3 scripts/upload.py output.pdf tidb-v${TARGET_BRANCH##*-}-en-manual.pdf;
           fi


### PR DESCRIPTION
To avoid a `release-*`-like branch triggering pdf build.