### PR TITLE
docs: bump pdf stable version to release-7.1

### DIFF
--- a/docs-cn/docs-cn-merge-pipeline.yaml
+++ b/docs-cn/docs-cn-merge-pipeline.yaml
@@ -5,6 +5,7 @@ triggers:
   push:
       onBranch:
       - "master"
+      - "release-7.1"
       - "release-7.0"
       - "release-6.6"
       - "release-6.5"
@@ -30,7 +31,7 @@ tasks:
           sudo bash -c 'echo "222.222.95.49 uc.qbox.me" >> /etc/hosts';
           if [ "${TARGET_BRANCH}" = "master" ]; then
             python3 scripts/upload.py output.pdf tidb-dev-zh-manual.pdf;
-          elif [ "${TARGET_BRANCH}" = "release-6.5" ]; then
+          elif [ "${TARGET_BRANCH}" = "release-7.1" ]; then
             python3 scripts/upload.py output.pdf tidb-stable-zh-manual.pdf;
           elif case "${TARGET_BRANCH}" in release-*) ;; *) false;; esac; then
             python3 scripts/upload.py output.pdf tidb-v${TARGET_BRANCH##*-}-zh-manual.pdf;

--- a/docs/docs-merge-pipeline.yaml
+++ b/docs/docs-merge-pipeline.yaml
@@ -5,6 +5,7 @@ triggers:
   push:
       onBranch:
       - "master"
+      - "release-7.1"
       - "release-7.0"
       - "release-6.6"
       - "release-6.5"
@@ -31,9 +32,11 @@ tasks:
           if [ "${TARGET_BRANCH}" = "master" ]; then
             python3 scripts/upload.py output.pdf tidb-dev-en-manual.pdf;
           elif [ "${TARGET_BRANCH}" = "release-6.5" ]; then
-            python3 scripts/upload.py output.pdf tidb-stable-en-manual.pdf;
             python3 scripts/merge_by_toc.py TOC-tidb-cloud.md doc_cloud.md tidb-cloud; scripts/generate_cloud_pdf.sh;
             python3 scripts/upload.py output_cloud.pdf tidbcloud-en-manual.pdf;
+            python3 scripts/upload.py output.pdf tidb-v6.5-en-manual.pdf;
+          elif [ "${TARGET_BRANCH}" = "release-7.1" ]; then
+            python3 scripts/upload.py output.pdf tidb-stable-en-manual.pdf;
           elif case "${TARGET_BRANCH}" in release-*) ;; *) false;; esac; then
             python3 scripts/upload.py output.pdf tidb-v${TARGET_BRANCH##*-}-en-manual.pdf;
           fi


### PR DESCRIPTION
Update the stable PDF version of TiDB and TiDB Cloud:

- TiDB: the stable PDF version is updated from release-6.5 to release-7.1.
- TiDB Cloud: the stable PDF version will remain at release-6.5 to ensure consistency with the current TiDB Cloud documentation.