### PR TITLE
tikv-migration: Upgrade to golang 1.20

### DIFF
--- a/tikv-migration/tikv-migration-verify-pipeline.yaml
+++ b/tikv-migration/tikv-migration-verify-pipeline.yaml
@@ -18,7 +18,7 @@ tasks:
             make unit_test_in_verify_ci
         utReport: cdc/cdc-junit-report.xml
         covReport: cdc/cdc-coverage.xml
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.18:latest"
+      image: "hub.pingcap.net/jenkins/centos7_golang-1.20:latest"
       resources:  
           requests:
               memory: "8000Mi"
@@ -36,7 +36,7 @@ tasks:
         shellScript: |
             cd cdc/
             make integration_test
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.18:latest"
+      image: "hub.pingcap.net/jenkins/centos7_golang-1.20:latest"
       resources:  
           requests:
               memory: "16000Mi"


### PR DESCRIPTION
Upgrade CI image to golang 1.20 as tikv/migration/cdc are using go 1.19 now (see https://github.com/tikv/migration/pull/337).